### PR TITLE
change package name to satisfy Plugin Analyzer

### DIFF
--- a/ratelimiter.go
+++ b/ratelimiter.go
@@ -1,5 +1,7 @@
-// Package ratelimiter defines a middleware that integrates with ratelimiter service.
-package ratelimiter
+// Package traefik_ratelimiter_middleware defines a middleware that integrates with ratelimiter service.
+//
+//nolint:stylecheck,revive
+package traefik_ratelimiter_middleware
 
 import (
 	"context"

--- a/ratelimiter_test.go
+++ b/ratelimiter_test.go
@@ -1,4 +1,5 @@
-package ratelimiter
+//nolint:stylecheck,revive
+package traefik_ratelimiter_middleware
 
 import (
 	"context"


### PR DESCRIPTION
https://github.com/argyle-engineering/traefik-ratelimiter-middleware/issues/4 is currently failing
https://community.traefik.io/t/plugin-how-to-debug-analyzer-issues/8201 suggests to change the package name to that of the repo name.